### PR TITLE
Fix #13: Margin issue in title

### DIFF
--- a/style.css
+++ b/style.css
@@ -217,7 +217,6 @@ nav {
 .video-list {
   /* border: 2px solid red; */
   display: flex;
-  justify-content: space-between;
   margin-bottom: 10px;
   color: white;
 }
@@ -225,6 +224,10 @@ nav {
 .video-list img {
   width: 200px;
   border-radius: 10px;
+}
+
+.video-list div {
+  padding-left: 15px;
 }
 
 .below-video-container {


### PR DESCRIPTION
Hello,
Hope you're doing well
As requested in issue #13, I have reduced the space between the video's thumbnail and description
So far, this is how it looks:

![image](https://github.com/user-attachments/assets/cc9b9534-5c60-438c-93e9-1d0103b9d802)

If at all I implemented the requirement incorrectly or made in mistake, then do let me know
Sincere apologies for my mistakes if you find any
Do let me know if there's anything else required from my end

Thanks and Regards,
Mohit Kambli